### PR TITLE
Make bean discovery all

### DIFF
--- a/microprofile-sample-canonical/src/main/webapp/WEB-INF/beans.xml
+++ b/microprofile-sample-canonical/src/main/webapp/WEB-INF/beans.xml
@@ -16,5 +16,5 @@
     limitations under the License.
   -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       bean-discovery-mode="annotated" version="1.1"
+       bean-discovery-mode="all" version="1.1"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"/>


### PR DESCRIPTION
Application as it stands fails to work on Payara and GlassFish this is because TopCDsEndpoint is not considered a CDI bean therefore Logger injection fails asTopsCDsEndpoint does not have a bean defining annotation.

I've opted to make beans.xml discovery to be all. Although I could add a bean defining annotation for TopCDsEndpoint.