### PR TITLE
Update swarm version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.resteasy>3.0.18.Final</version.resteasy>
         <version.swagger>1.5.9</version.swagger>
         <!--Swarm-->
-        <version.wildfly-swarm>2016.10-SNAPSHOT</version.wildfly-swarm>
+        <version.wildfly-swarm>2016.10.0</version.wildfly-swarm>
         <!-- Test -->
         <version.arquillian>1.0.0.Alpha3</version.arquillian>
         <version.arquillian.wildfly.remote>8.2.1.Final</version.arquillian.wildfly.remote>


### PR DESCRIPTION
- As WildFly Swarm release 2010.10.0 is out, we should change the maven version number
- related to issue-28