### PR TITLE
Initial checkin of microprofile-config sample. Hammock updated to 2.1…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,7 @@ Give different examples using the MicroProfile :
 
 * **Canonical** Simplest sample using JAX-RS 2.0 / CDI 1.2 / JSON-P 1.0
 * **Swagger** Adding Swagger to the canonical sample
+* **Config** Sample for MicroProfile Config
 
 ## Building
 

--- a/microprofile-sample-config/README.adoc
+++ b/microprofile-sample-config/README.adoc
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+= MicroProfile Config Sample
+
+This sample shows how to use the MicroProfile Config API.
+
+== Access the Application
+The following REST APi is provided by the application. +
+
+* **/list/all**: Lists all configurations of the application
+* **/list/users**: List all users provided as configuration
+* **/list/source/{name}**: Lists the configurations of the configuration source with the given name
+
+
+== Expected Configurations
+The following system properties are supported: +
+
+* **allowedUsers**: The list of users with password in the form of **user:pwd{,user:pwd}**, which is required
+* **listAllConfigAllowed**: True, if all configs are allowed to be loaded by clients, defaults to false
+
+== Running with Hammock
+When running this sample with Hammock, then configurations are expected to be provided via Java System Properties
+during startup. +
+
+To build this sample execute
+
+* ``mvn clean install -Phammock``
+
+To run the sample go to execute
+
+* ``java -jar -DallowedUsers=<user_pwd_list> [-DlistAllConfigAllowed=<true|false>] target/config-1.0.0-SNAPSHOT-hammock.jar``

--- a/microprofile-sample-config/pom.xml
+++ b/microprofile-sample-config/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>activation</artifactId>
             <version>1.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/microprofile-sample-config/pom.xml
+++ b/microprofile-sample-config/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>org.eclipse.microprofile.sample</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>config</artifactId>
+    <packaging>${packaging.type}</packaging>
+    <name>Microprofile Samples :: Config</name>
+
+    <dependencies>
+        <!-- JBoss Logging required due to older version from resteasy client -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <!-- JAVA EE -->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+        </dependency>
+
+        <!-- Otherwise ClassNotFoundExceptions occur -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>microprofile-sample-config</finalName>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>hammock</id>
+            <dependencies>
+                <dependency>
+                    <groupId>ws.ament.hammock</groupId>
+                    <artifactId>dist-microprofile</artifactId>
+                    <exclusions>
+                        <!-- Don't want to use apache cxf -->
+                        <exclusion>
+                            <groupId>ws.ament.hammock</groupId>
+                            <artifactId>rest-cxf</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <!-- Want to use RESTeasy-->
+                <dependency>
+                    <groupId>ws.ament.hammock</groupId>
+                    <artifactId>rest-resteasy</artifactId>
+                    <version>${hammock.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>ws.ament.hammock</groupId>
+                    <artifactId>test-arquillian</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-weld-embedded</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/RestApplication.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/RestApplication.java
@@ -1,3 +1,23 @@
+/**********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
 package org.eclipse.microprofile.sample.config.configuration;
 
 import javax.enterprise.context.ApplicationScoped;

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/RestApplication.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/RestApplication.java
@@ -1,0 +1,16 @@
+package org.eclipse.microprofile.sample.config.configuration;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * This class represents the jax-rs application.
+ *
+ * @author Thomas Herzog <herzog.thomas81@gmail.com>
+ * @since 8/2/2018
+ */
+@ApplicationPath("/")
+@ApplicationScoped
+public class RestApplication extends Application {
+}

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/converter/UserConfigConverter.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/converter/UserConfigConverter.java
@@ -1,3 +1,23 @@
+/**********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
 package org.eclipse.microprofile.sample.config.configuration.converter;
 
 import org.eclipse.microprofile.config.spi.Converter;

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/converter/UserConfigConverter.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/converter/UserConfigConverter.java
@@ -1,0 +1,24 @@
+package org.eclipse.microprofile.sample.config.configuration.converter;
+
+import org.eclipse.microprofile.config.spi.Converter;
+import org.eclipse.microprofile.sample.config.configuration.model.User;
+
+/**
+ * Expects a string in the format: 'username:pass' and converts it to a list of {@link User}.
+ * The item separator is supposed to be ',', which is handled in the microprofile-config implementation.
+ *
+ * @author Thomas Herzog <herzog.thomas81@gmail.com>
+ * @since 8/2/2018
+ */
+public class UserConfigConverter implements Converter<User> {
+
+    @Override
+    public User convert(String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            final String[] userParts = value.split(":");
+            return new User(userParts[0], userParts[1]);
+        }
+
+        throw new IllegalArgumentException(String.format("Cannot convert null or empty string to user: '%s'", value));
+    }
+}

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/model/User.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/model/User.java
@@ -1,3 +1,23 @@
+/**********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
 package org.eclipse.microprofile.sample.config.configuration.model;
 
 import java.io.Serializable;

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/model/User.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/configuration/model/User.java
@@ -1,0 +1,49 @@
+package org.eclipse.microprofile.sample.config.configuration.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * This is a configuration item model, which represents a User instance, which is created
+ * by a microprofile-config converter {@link org.eclipse.microprofile.sample.config.configuration.converter.UserConfigConverter}
+ *
+ * @author Thomas Herzog <herzog.thomas81@gmail.com>
+ * @since 8/2/2018
+ */
+public class User implements Serializable {
+
+    private final String username;
+    private final String pass;
+
+    public User(String username,
+                String pass) {
+        this.username = Objects.requireNonNull(username, "Username must not be null");
+        this.pass = Objects.requireNonNull(pass, "Pass must not be null");
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPass() {
+        return pass;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        User that = (User) o;
+
+        if (!username.equals(that.username)) return false;
+        return pass.equals(that.pass);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = username.hashCode();
+        result = 31 * result + pass.hashCode();
+        return result;
+    }
+}

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/rest/ConfigResourceImpl.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/rest/ConfigResourceImpl.java
@@ -1,0 +1,103 @@
+package org.eclipse.microprofile.sample.config.rest;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.sample.config.configuration.converter.UserConfigConverter;
+import org.eclipse.microprofile.sample.config.configuration.model.User;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * This is a example JAX-RS endpoint, which provides access to runtime available configurations,
+ * which are provided via microprofile-config specification.
+ *
+ * @author Thomas Herzog <herzog.thomas81@gmail.com>
+ * @since 8/2/2018
+ */
+@Path("/")
+@ApplicationScoped
+public class ConfigResourceImpl {
+
+    /**
+     * Allows to access all ConfigSources and configurations programmatically
+     */
+    @Inject
+    private Config config;
+
+    /**
+     * Injects a converted configuration.
+     *
+     * @see UserConfigConverter
+     */
+    @Inject
+    @ConfigProperty(name = "allowedUsers")
+    private List<User> allowedUsers;
+
+    /**
+     * Injects a converted boolean value, which controls listing of all configurations.
+     * The implementation of the microprofile-config-api provides converters for common java types such as boolean.
+     */
+    @Inject
+    @ConfigProperty(name = "listAllConfigAllowed", defaultValue = "false")
+    private boolean listAllConfigAllowed;
+
+    /**
+     * @return all microprofile-config provided configurations
+     */
+    @GET
+    @Path("/list/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Map<String, String>> listAll() {
+        if (!listAllConfigAllowed) {
+            throw new ForbiddenException("Access of listing all configurations is not enabled");
+        }
+
+        return Stream.of(config.getConfigSources())
+                     .flatMap(s -> StreamSupport.stream(s.spliterator(),
+                                                        false))
+                     .collect(Collectors.toMap(s -> s.getName(), s -> s.getProperties()));
+    }
+
+    /**
+     * @return all via configuration provided users.
+     */
+    @GET
+    @Path("/list/users")
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<User> listUsers() {
+        return allowedUsers;
+    }
+
+    /**
+     * @param name the name of the config source to fetch configurations from.
+     * @return the config source provided configurations
+     * @throws NotFoundException if no config source exists for the given name
+     */
+    @GET
+    @Path("/list/source/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, String> listConfigSource(@PathParam("name") String name) {
+        // Get config from current ClassLoader instead of injection point
+        final Config config = ConfigProvider.getConfig();
+        final Optional<ConfigSource> source = Stream.of(config.getConfigSources())
+                                                    .flatMap(s -> StreamSupport.stream(s.spliterator(),
+                                                                                       false))
+                                                    .filter(s -> s.getName().equalsIgnoreCase(name))
+                                                    .findFirst();
+
+        return source.orElseThrow(() -> new NotFoundException(String.format("No ConfigSource found for name: '%s'",
+                                                                            name.toUpperCase())))
+                     .getProperties();
+    }
+}

--- a/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/rest/ConfigResourceImpl.java
+++ b/microprofile-sample-config/src/main/java/org/eclipse/microprofile/sample/config/rest/ConfigResourceImpl.java
@@ -1,3 +1,23 @@
+/**********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
 package org.eclipse.microprofile.sample.config.rest;
 
 import org.eclipse.microprofile.config.Config;

--- a/microprofile-sample-config/src/main/resources/META-INF/beans.xml
+++ b/microprofile-sample-config/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Copyright (C) 2016, 2017 Antonio Goncalves and others.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied.
+
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       bean-discovery-mode="annotated" version="1.2"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"/>

--- a/microprofile-sample-config/src/main/resources/META-INF/beans.xml
+++ b/microprofile-sample-config/src/main/resources/META-INF/beans.xml
@@ -1,22 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-
-    Copyright (C) 2016, 2017 Antonio Goncalves and others.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-    implied.
-
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
+/**********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
 -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        bean-discovery-mode="annotated" version="1.2"

--- a/microprofile-sample-config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/microprofile-sample-config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,0 +1,1 @@
+org.eclipse.microprofile.sample.config.configuration.converter.UserConfigConverter

--- a/microprofile-sample-config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/microprofile-sample-config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,1 +1,21 @@
+#/**********************************************************************
+# * Copyright (c) 2017 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICES file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * You may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# **********************************************************************/
 org.eclipse.microprofile.sample.config.configuration.converter.UserConfigConverter

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <modules>
         <module>microprofile-sample-canonical</module>
         <module>microprofile-sample-swagger</module>
+        <module>microprofile-sample-config</module>
     </modules>
 
     <properties>
@@ -78,7 +79,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- hammock -->
-        <hammock.version>0.4.0</hammock.version>
+        <hammock.version>2.1</hammock.version>
         <arquillian-weld-embedded.version>2.0.0.Beta3</arquillian-weld-embedded.version>
         <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
         <packaging.type>war</packaging.type>
@@ -590,6 +591,24 @@
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>
+                    <!--
+                        Could also be used and does not require that much configuration
+                    <plugin>
+                        <groupId>com.github.chrisdchristo</groupId>
+                        <artifactId>capsule-maven-plugin</artifactId>
+                        <version>1.5.1</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <appClass>ws.ament.hammock.Bootstrap</appClass>
+                                    <type>fat</type>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>-->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <version.javaee>7.0</version.javaee>
         <version.resteasy>3.0.18.Final</version.resteasy>
         <version.swagger>1.5.9</version.swagger>
+        <version.microprofile-config>1.2</version.microprofile-config>
         <skipLicenseCheck>false</skipLicenseCheck>
         <!--Swarm -->
         <version.wildfly-swarm>2016.12.0</version.wildfly-swarm>
@@ -108,6 +109,13 @@
                 <version>${version.wildfly-swarm}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Microprofile -->
+            <dependency>
+                <groupId>org.eclipse.microprofile.config</groupId>
+                <artifactId>microprofile-config-api</artifactId>
+                <version>${version.microprofile-config}</version>
             </dependency>
 
             <!-- OTHERS -->


### PR DESCRIPTION
This is a new sample for microprofile-config-api usage.
Please review and give me a feedback, if this sample is properly implemented and can be used as a sample for eclipse/microprofile-samples repository.

**How to build:** mvn clean install -Phammock
**How to run:**     java -DallowedUsers="het:mypass" -DlistAllConfigAllowed="true"  -jar .\config-1.0.0-SNAPSHOT-hammock.jar

**How to access:**
- http://localhost:8080/list/all
  Returns all config sources along with their set configurations, if **listAllConfigAllowed** configuration property is set to true
- http://localhost:8080/list/users
  Returns all users provided by **allowedUsers** configuration property
- http://localhost:8080/list/source/<name\>
  Returns all configurations of the given config source

This is the first draft of the microprofile-sample-config project.

**Changes:**
- Initial check in of new microprofile-sample-config
- Update hammock version to 2.1
- Had to add additional dependencies to new sample because ClassNotFoundExceptions occurred during startup
- Added capsule-maven-plugin (commented out) which could replace maven-shade-plugin 

Signed-off-by: Thomas Herzog <herzog.thomas81@gmail.com>